### PR TITLE
add opton to plot fahrenheit to spatial temperature maps

### DIFF
--- a/R/plot_bottom_temp_seasonal_gridded.r
+++ b/R/plot_bottom_temp_seasonal_gridded.r
@@ -4,14 +4,15 @@
 #'
 #' @param shadedRegion Numeric vector. Years denoting the shaded region of the plot (most recent 10), passed from plot function
 #' @param report Character string. Which SOE report ("MidAtlantic", "NewEngland"), passed from plot function
-#'
+#' @param scale character string. celsius or fahrenheit. Default = "celsius"
 #'
 #' @return ggplot object
 #'
 #' @export
 
 plot_bottom_temp_seasonal_gridded <- function(shadedRegion = NULL,
-                                              report = "MidAtlantic") {
+                                              report = "MidAtlantic",
+                                              scale = "celsius") {
 
 
   setup <- ecodata::plot_setup(shadedRegion = shadedRegion,
@@ -51,6 +52,29 @@ plot_bottom_temp_seasonal_gridded <- function(shadedRegion = NULL,
     dplyr::mutate(Var = factor(Var, levels = c("winter","spring","summer","fall")))
 
 
+
+  if (scale == "fahrenheit") {
+    # convert celsius to fahrenheit
+    fix <- fix |>
+      dplyr::mutate(Value = (9/5)*Value + 32)
+    label <- "Temp.\nAnomaly (\u00B0F)"
+    breaks <- c(41, 50, 59, 68, 77)
+    labelLegend <- c("41", "50", "59", "68", "77")
+    limits <- c(39,80)
+    midpoint <- 59
+  } else {
+    label <- "Temp.\nAnomaly (\u00B0C)"
+    breaks <- c(5,10,15,20,25)
+    labelLegend <- c("5", "10", "15", "20", "25")
+    limits <- c(5,25)
+    midpoint <- 15
+  }
+
+ # fix <- fix |> dplyr::mutate(Value = replace(Value, Value > maxVal, maxVal))
+
+
+
+
   p <- ggplot2::ggplot(data = fix)+
     ggplot2::geom_tile(ggplot2::aes(x = Longitude, y = Latitude, fill = Value)) +
     ggplot2::geom_sf(data = ecodata::coast, size = setup$map.lwd) +
@@ -58,13 +82,15 @@ plot_bottom_temp_seasonal_gridded <- function(shadedRegion = NULL,
     ggplot2::coord_sf(xlim = xlims, ylim = ylims) +
     ggplot2::facet_wrap(Var~.)+
     ecodata::theme_map() +
-    #ggplot2::scale_fill_gradient2(name = 'Bottom \n Temp',
-                                  #low = scales::muted("blue"),
-                                  #mid = "white",
-                                  #high = scales::muted("red"),
-                                  #limits = c(5,25),
-                                  #labels = c("5", "10", "15", "20", "25")) +
-    ggplot2::scale_fill_viridis_c(option = 'B',name = 'Bottom \n Temp')+
+    #scales::show_col(viridis::inferno(n=3)) Find the colors
+    ggplot2::scale_fill_gradient2(name = label,
+                                  low = "#000004FF",
+                                  mid = "#BB3754FF",
+                                  high = "#FCFFA4FF",
+                                  limits = limits,
+                                  labels = labelLegend,
+                                  midpoint = midpoint) +
+    #ggplot2::scale_color_viridis_c(option = 'B',name = 'Bottom \n Temp')+
     ggplot2::ggtitle('Seasonal Mean Bottom Temperature')+
     ggplot2::xlab("Longitude") +
     ggplot2::ylab("Latitude") +
@@ -75,7 +101,6 @@ plot_bottom_temp_seasonal_gridded <- function(shadedRegion = NULL,
                    strip.text=ggplot2::element_text(hjust=0),
                    axis.text = ggplot2::element_text(size = 8),
                    axis.title.y = ggplot2::element_text(angle = 90))+
-    ggplot2::guides(fill = ggplot2::guide_legend(title="LEFT", title.position = "left")) +
     ecodata::theme_title() +
 
     ecodata::theme_ts()

--- a/R/plot_bottom_temp_seasonal_gridded.r
+++ b/R/plot_bottom_temp_seasonal_gridded.r
@@ -75,7 +75,9 @@ plot_bottom_temp_seasonal_gridded <- function(shadedRegion = NULL,
                    strip.text=ggplot2::element_text(hjust=0),
                    axis.text = ggplot2::element_text(size = 8),
                    axis.title.y = ggplot2::element_text(angle = 90))+
+    ggplot2::guides(fill = ggplot2::guide_legend(title="LEFT", title.position = "left")) +
     ecodata::theme_title() +
+
     ecodata::theme_ts()
 
 

--- a/R/plot_ches_bay_sst.R
+++ b/R/plot_ches_bay_sst.R
@@ -4,6 +4,7 @@
 #'
 #' @param shadedRegion Numeric vector. Years denoting the shaded region of the plot (most recent 10)
 #' @param report Character string. Which SOE report ("MidAtlantic" only, default)
+#' @param scale character string. celsius or fahrenheit. Default = "celsius"
 #'
 #' @return ggplot object
 #'
@@ -12,7 +13,8 @@
 #'
 
 plot_ches_bay_sst <- function(shadedRegion = NULL,
-                              report="MidAtlantic") {
+                              report="MidAtlantic",
+                              scale = "celsius") {
 
   # generate plot setup list (same for all plot functions)
   setup <- ecodata::plot_setup(shadedRegion = shadedRegion,
@@ -43,8 +45,26 @@ plot_ches_bay_sst <- function(shadedRegion = NULL,
                                               "Summer",
                                               "Fall"))
 
-  sst <- sst |> dplyr::mutate(Value = replace(Value, Value > 5, 5))
+  if (scale == "fahrenheit") {
+    # convert celsius to fahrenheit
+    sst <- sst |>
+      dplyr::mutate(Value = (9/5)*Value + 32)
+    label <- "Temp.\nAnomaly (\u00B0F)"
+    breaks <- c(23,27.5,32,36.5,41)
+    labelLegend <- c("<23", "27.5", "32", "36.5", ">41")
+    limits <- c(23,41)
+    maxVal <- 41
+    midpoint <- 32
+  } else {
+    label <- "Temp.\nAnomaly (\u00B0C)"
+    breaks <- c(-5,-2.5,0,2.5,5)
+    labelLegend <- c("<-5", "-2.5", "0", "2.5", ">5")
+    limits <- c(-5,5)
+    maxVal <- 5
+    midpoint <- 0
+  }
 
+  sst <- sst |> dplyr::mutate(Value = replace(Value, Value > maxVal, maxVal))
 
   # code for generating plot object p
   # ensure that setup list objects are called as setup$...
@@ -54,15 +74,17 @@ plot_ches_bay_sst <- function(shadedRegion = NULL,
   p <- sst |>
     ggplot2::ggplot() +
     ggplot2::geom_sf(data = ecodata::coast, size = setup$map.lwd) +
-    ggplot2::scale_fill_gradient2(name = "Temp.\nAnomaly (C)",
-                                  low = scales::muted("blue"),
-                                  mid = "white",
-                                  high = scales::muted("red"),
-                                  limits = c(-4,4),
-                                  labels = c("<-5", "-2.5", "0", "2.5", ">5")) +
     ggplot2::coord_sf(crs = setup$crs, xlim = setup$xlims, ylim = setup$ylims) +
 
     ggplot2::geom_tile(data = sst, ggplot2::aes(x = Latitude, y = Longitude,fill = Value)) +
+    ggplot2::scale_fill_gradient2(name = label,
+                                  low = scales::muted("blue"),
+                                  mid = "white",
+                                  high = scales::muted("red"),
+                                  limits = limits,
+                                  labels = labelLegend,
+                                  breaks = breaks,
+                                  midpoint = midpoint) +
     ggplot2::facet_wrap(Var~.) +
     ecodata::theme_map() +
     ggplot2::ggtitle("Chesapeake Bay SST anomaly") +

--- a/R/plot_ches_bay_sst.R
+++ b/R/plot_ches_bay_sst.R
@@ -48,13 +48,13 @@ plot_ches_bay_sst <- function(shadedRegion = NULL,
   if (scale == "fahrenheit") {
     # convert celsius to fahrenheit
     sst <- sst |>
-      dplyr::mutate(Value = (9/5)*Value + 32)
+      dplyr::mutate(Value = (9/5)*Value)
     label <- "Temp.\nAnomaly (\u00B0F)"
-    breaks <- c(23,27.5,32,36.5,41)
-    labelLegend <- c("<23", "27.5", "32", "36.5", ">41")
-    limits <- c(23,41)
-    maxVal <- 41
-    midpoint <- 32
+    breaks <- c(-9.0, -4.5,  0.0,  4.5,  9.0)
+    labelLegend <- c("<-9", "-4.5", "0", "4.5", ">9")
+    limits <- c(-9,9)
+    maxVal <- 9
+    midpoint <- 0
   } else {
     label <- "Temp.\nAnomaly (\u00B0C)"
     breaks <- c(-5,-2.5,0,2.5,5)

--- a/man/plot_bottom_temp_seasonal_gridded.Rd
+++ b/man/plot_bottom_temp_seasonal_gridded.Rd
@@ -4,12 +4,18 @@
 \alias{plot_bottom_temp_seasonal_gridded}
 \title{plot bottom temperature seasonal gridded data}
 \usage{
-plot_bottom_temp_seasonal_gridded(shadedRegion = NULL, report = "MidAtlantic")
+plot_bottom_temp_seasonal_gridded(
+  shadedRegion = NULL,
+  report = "MidAtlantic",
+  scale = "celsius"
+)
 }
 \arguments{
 \item{shadedRegion}{Numeric vector. Years denoting the shaded region of the plot (most recent 10), passed from plot function}
 
 \item{report}{Character string. Which SOE report ("MidAtlantic", "NewEngland"), passed from plot function}
+
+\item{scale}{character string. celsius or fahrenheit. Default = "celsius"}
 }
 \value{
 ggplot object

--- a/man/plot_ches_bay_sst.Rd
+++ b/man/plot_ches_bay_sst.Rd
@@ -4,12 +4,18 @@
 \alias{plot_ches_bay_sst}
 \title{plot ches_bay_sst}
 \usage{
-plot_ches_bay_sst(shadedRegion = NULL, report = "MidAtlantic")
+plot_ches_bay_sst(
+  shadedRegion = NULL,
+  report = "MidAtlantic",
+  scale = "celsius"
+)
 }
 \arguments{
 \item{shadedRegion}{Numeric vector. Years denoting the shaded region of the plot (most recent 10)}
 
 \item{report}{Character string. Which SOE report ("MidAtlantic" only, default)}
+
+\item{scale}{character string. celsius or fahrenheit. Default = "celsius"}
 }
 \value{
 ggplot object

--- a/man/plot_seasonal_sst_anomaly_gridded.Rd
+++ b/man/plot_seasonal_sst_anomaly_gridded.Rd
@@ -4,9 +4,15 @@
 \alias{plot_seasonal_sst_anomaly_gridded}
 \title{plot seasonal_sst_anomaly_gridded}
 \usage{
-plot_seasonal_sst_anomaly_gridded(shadedRegion = NULL, report = "MidAtlantic")
+plot_seasonal_sst_anomaly_gridded(
+  shadedRegion = NULL,
+  report = "MidAtlantic",
+  scale = "celsius"
+)
 }
 \arguments{
+\item{scale}{character string. celsius or fahrenheit. Default = "celsius"}
+
 \item{season}{Character string. Season to plot. (Default = NULL, plot all seasons)}
 
 \item{region}{Character vector. Regional EPUs ("GB","MAB") to overly on figure. (Default = NULL, use all)}


### PR DESCRIPTION
added `scale` argument (values = "celsius" or "fahrenheit") to following plot functons
- plot_bottom_temp_seasonal_gridded
- plot_ches_bay_sst
- plot_Seasonal_sst_anomaly_gridde