### PR TITLE
short term trend application

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,8 @@ Imports:
   flextable,
   heatwaveR,
   forcats,
-  patchwork
+  patchwork,
+  arfit
 Suggests:
   knitr,
   rmarkdown,
@@ -44,6 +45,8 @@ Suggests:
 	mgcv,
 	zoo,
 	rlang
+Remotes:
+  andybeet/arfit
 VignetteBuilder: knitr
 RoxygenNote: 7.3.1
 Depends: 

--- a/R/GeomLM.R
+++ b/R/GeomLM.R
@@ -6,7 +6,7 @@ GeomLM <- ggplot2::ggproto("GeomLM",
 
 
                             default_aes = ggplot2::aes(size = 2, color = NA,fill = NA,
-                                                       linetype = 2, alpha = 0.7),
+                                                       linetype = 1, alpha = 0.7),
 
                             draw_key = ggplot2::draw_key_path,
 
@@ -17,9 +17,9 @@ GeomLM <- ggplot2::ggproto("GeomLM",
 
                               #Select default color based on positive/negative trend
                               if (coords$y[1] < coords$y[which.max(coords$x)]){
-                                first_row$color <- "orange"
+                                first_row$color <- "orange4"
                               } else {
-                                first_row$color <- "purple"
+                                first_row$color <- "purple4"
                               }
 
                               grid::linesGrob(

--- a/R/StatLM.R
+++ b/R/StatLM.R
@@ -17,57 +17,60 @@ StatLM <- ggplot2::ggproto("StatLM",
                               #nBootSamples <- 499
 ###########################################################################
                               `%>%` <- magrittr::`%>%`
-                              dataUse <- data %>%
-                                dplyr::arrange(x) %>%
-                                # Select last n years
-                                dplyr::filter(x %in% (max(x)-(n-1)):max(x)) %>%
-                                dplyr::mutate(x = x-min(x)+1)
 
-                              # print("########RAW##########")
-                               #print(data)
-                              # print((max(data$x)-(n-1)))
-                              # print(max(data$x))
-                              # print(data$x-min(data$x)+1)
-                              #
-                              # print("#######USE##########")
-                              # print(dataUse)
-                              # print("#######################")
+                              if(n>4) {
+                                dataUse <- data %>%
+                                  dplyr::arrange(x) %>%
+                                  # Select last n years
+                                  dplyr::filter(x %in% (max(x)-(n-1)):max(x)) %>%
+                                  dplyr::mutate(x = x-min(x)+1)
 
-                              xmax <- max(data$x)
-                              xmin <- xmax-n +1
+                                # print("########RAW##########")
+                                 #print(data)
+                                # print((max(data$x)-(n-1)))
+                                # print(max(data$x))
+                                # print(data$x-min(data$x)+1)
+                                #
+                                # print("#######USE##########")
+                                # print(dataUse)
+                                # print("#######################")
 
-                              # Linear model with AR1 error
-                              linear_ar1 <-
-                                try(arfit::fit_real_data(dataUse,nBootSims=nBootSamples))
-                              #print(linear_ar1$pValue)
-                              if (is.na(linear_ar1$pValue)){
-                                return(best_lm <- data.frame(model = NA,
-                                                             coefs..Intercept = NA,
-                                                             coefs.time = NA,
-                                                             coefs.time2 = NA,
-                                                             pval = NA))
+                                xmax <- max(data$x)
+                                xmin <- xmax-n +1
 
-                              }
+                                # Linear model with AR1 error
+                                linear_ar1 <-
+                                  try(arfit::fit_real_data(dataUse,nBootSims=nBootSamples))
+                                #print(linear_ar1$pValue)
+                                if (is.na(linear_ar1$pValue)){
+                                  return(best_lm <- data.frame(model = NA,
+                                                               coefs..Intercept = NA,
+                                                               coefs.time = NA,
+                                                               coefs.time2 = NA,
+                                                               pval = NA))
 
-                              # pick out model. Either null (no trend) or alternative (trend)
-                              if (linear_ar1$pValue <= pValThreshold) { # Trend detected
-                                coefs <- linear_ar1$alt$betaEst
-                                xMat <- as.matrix(cbind(rep(1,n),dataUse$x)) # design matrix
+                                }
 
-                              # } else { # no trend
-                              #   coefs <- linear_ar1$null$betaEst
-                              #   xMat <- as.matrix(cbind(rep(1,n))) # design matrix
-                              # }
+                                # pick out model. Either null (no trend) or alternative (trend)
+                                if (linear_ar1$pValue <= pValThreshold) { # Trend detected
+                                  coefs <- linear_ar1$alt$betaEst
+                                  xMat <- as.matrix(cbind(rep(1,n),dataUse$x)) # design matrix
 
-                                # predict
+                                # } else { # no trend
+                                #   coefs <- linear_ar1$null$betaEst
+                                #   xMat <- as.matrix(cbind(rep(1,n))) # design matrix
+                                # }
 
-                                predy <- xMat %*% coefs
+                                  # predict
 
-                                newtime <- seq(xmin, xmax, length.out=n)
-                                fittedData <- data.frame(x = newtime,
-                                                     y = predy)
+                                  predy <- xMat %*% coefs
 
-                                return(fittedData)
+                                  newtime <- seq(xmin, xmax, length.out=n)
+                                  fittedData <- data.frame(x = newtime,
+                                                       y = predy)
+
+                                  return(fittedData)
+                                }
                               }
 
                             }

--- a/R/StatLM.R
+++ b/R/StatLM.R
@@ -19,14 +19,12 @@ StatLM <- ggplot2::ggproto("StatLM",
                               `%>%` <- magrittr::`%>%`
                               dataUse <- data %>%
                                 dplyr::arrange(x) %>%
-                                #Fill in time steps if there are missing values
-                                #tidyr::complete(x = tidyr::full_seq(min(data$x):max(data$x),1)) %>%
-                                # Select last 11 years
+                                # Select last n years
                                 dplyr::filter(x %in% (max(x)-(n-1)):max(x)) %>%
                                 dplyr::mutate(x = x-min(x)+1)
 
                               # print("########RAW##########")
-                              # print(data)
+                               #print(data)
                               # print((max(data$x)-(n-1)))
                               # print(max(data$x))
                               # print(data$x-min(data$x)+1)
@@ -41,7 +39,7 @@ StatLM <- ggplot2::ggproto("StatLM",
                               # Linear model with AR1 error
                               linear_ar1 <-
                                 try(arfit::fit_real_data(dataUse,nBootSims=nBootSamples))
-                              ##print(linear_ar1)
+                              #print(linear_ar1$pValue)
                               if (is.na(linear_ar1$pValue)){
                                 return(best_lm <- data.frame(model = NA,
                                                              coefs..Intercept = NA,

--- a/R/plot_gsi.R
+++ b/R/plot_gsi.R
@@ -5,7 +5,7 @@
 #' @param shadedRegion Numeric vector. Years denoting the shaded region of the plot (most recent 10)
 #' @param report Character string. Which SOE report ("MidAtlantic", "NewEngland")
 #' @param varName Character string. Which variable to plot ("gsi","westgsi")
-#' @param n Numeric scalar. Number of values used in short term trend
+#' @param n Numeric scalar. Number of years used (from most recent year) to estimate short term trend . Default = 0 (No trend calculated)
 #'
 #' @return ggplot object
 #'
@@ -16,7 +16,7 @@
 plot_gsi <- function(shadedRegion = NULL,
                      report="MidAtlantic",
                      varName = "gsi",
-                     n = 10) {
+                     n = 0) {
 
   # generate plot setup list (same for all plot functions)
   setup <- ecodata::plot_setup(shadedRegion = shadedRegion,

--- a/R/plot_gsi.R
+++ b/R/plot_gsi.R
@@ -5,6 +5,8 @@
 #' @param shadedRegion Numeric vector. Years denoting the shaded region of the plot (most recent 10)
 #' @param report Character string. Which SOE report ("MidAtlantic", "NewEngland")
 #' @param varName Character string. Which variable to plot ("gsi","westgsi")
+#' @param n Numeric scalar. Number of values used in short term trend
+#'
 #' @return ggplot object
 #'
 #'
@@ -13,7 +15,8 @@
 
 plot_gsi <- function(shadedRegion = NULL,
                      report="MidAtlantic",
-                     varName = "gsi") {
+                     varName = "gsi",
+                     n = 10) {
 
   # generate plot setup list (same for all plot functions)
   setup <- ecodata::plot_setup(shadedRegion = shadedRegion,
@@ -61,6 +64,7 @@ plot_gsi <- function(shadedRegion = NULL,
     ggplot2::ylab("Anomaly")+
     ggplot2::xlab(ggplot2::element_blank())+
     ecodata::geom_gls()+
+    ecodata::geom_lm(n=n)+
     ecodata::theme_ts()+
     ggplot2::geom_hline(ggplot2::aes(yintercept = hline),
                         linewidth = setup$hline.size,

--- a/man/plot_gsi.Rd
+++ b/man/plot_gsi.Rd
@@ -4,7 +4,7 @@
 \alias{plot_gsi}
 \title{plot gulf stream index}
 \usage{
-plot_gsi(shadedRegion = NULL, report = "MidAtlantic", varName = "gsi", n = 10)
+plot_gsi(shadedRegion = NULL, report = "MidAtlantic", varName = "gsi", n = 0)
 }
 \arguments{
 \item{shadedRegion}{Numeric vector. Years denoting the shaded region of the plot (most recent 10)}
@@ -13,7 +13,7 @@ plot_gsi(shadedRegion = NULL, report = "MidAtlantic", varName = "gsi", n = 10)
 
 \item{varName}{Character string. Which variable to plot ("gsi","westgsi")}
 
-\item{n}{Numeric scalar. Number of values used in short term trend}
+\item{n}{Numeric scalar. Number of years used (from most recent year) to estimate short term trend . Default = 0 (No trend calculated)}
 }
 \value{
 ggplot object

--- a/man/plot_gsi.Rd
+++ b/man/plot_gsi.Rd
@@ -4,7 +4,7 @@
 \alias{plot_gsi}
 \title{plot gulf stream index}
 \usage{
-plot_gsi(shadedRegion = NULL, report = "MidAtlantic", varName = "gsi")
+plot_gsi(shadedRegion = NULL, report = "MidAtlantic", varName = "gsi", n = 10)
 }
 \arguments{
 \item{shadedRegion}{Numeric vector. Years denoting the shaded region of the plot (most recent 10)}
@@ -12,6 +12,8 @@ plot_gsi(shadedRegion = NULL, report = "MidAtlantic", varName = "gsi")
 \item{report}{Character string. Which SOE report ("MidAtlantic", "NewEngland")}
 
 \item{varName}{Character string. Which variable to plot ("gsi","westgsi")}
+
+\item{n}{Numeric scalar. Number of values used in short term trend}
 }
 \value{
 ggplot object


### PR DESCRIPTION
## ggplot geom for short term trend

* Modified the GEOM related functions `GeomLM`, `geom_lm`, `StatLM` to allow for fitting of short term trend. (This calls [`arfit`](https://github.com/andybeet/arfit/) package, added to DESCRIPTION file)
* Changed the colors of the short term trend lines to be a darker color, made line solid
* Only calculates a trend if n >4

## Plot function example

Modified the `plot_gsi` function to take an argument `n`, specifying the number of data points to use in the trend estimation. It defaults to n=0 to ensure backward compatibility (no trend estimated)

To view changes type: `ecodata::plot_gsi(n=10)` or `ecodata::plot_gsi(n=20)`

**We can make any modifications to the appearance of the trend line, change color, thickness, style etc.**