### PR TITLE
Change plot behavior to choose GLORYS+ROMS or MOM6

### DIFF
--- a/R/plot_bottom_temp_model_anom.R
+++ b/R/plot_bottom_temp_model_anom.R
@@ -34,13 +34,19 @@ plot_bottom_temp_model_anom <- function(shadedRegion=NULL,
 
 
   fix <- ecodata::bottom_temp_model_anom |>
-    dplyr::filter(Source %in% plottype) |>
     dplyr::filter(EPU %in% filterEPUs) |>
     dplyr::mutate(Time = as.numeric(Time),
                   Var = stringr::str_to_title(stringr::str_extract(Var,"Winter|Spring|Summer|Fall|Annual"))) |>
     dplyr::filter(!Var == "NA") |>
     dplyr::mutate(Source = as.factor(Source)) |>
     dplyr::arrange(Source,Time,EPU,Var)
+
+  # Add statement to properly assign source (GLORYS+PSY or MOM6)
+  if (plottype == "MOM6") {
+    fix <- dplyr::filter(fix, Source == "MOM6")
+  } else {
+    fix <- dplyr::filter(fix, (Source == "GLORYS" & Time >= 1993) | (Source == "ROMS") | (Source != "MOM6"))
+  }
 
   fix$Var <- factor(fix$Var, levels= c("Winter","Spring","Summer","Fall", "Annual"))
 


### PR DESCRIPTION
Changed `plot_bottom_temp_model_anom` to use GLORYS + PSY when "GLORYS" is selected as the plottype. This was the original behavior of the plot function. Using plottype = "MOM6" will still isolate the MOM6 series, plotting it by itself.

@jcaracappa1 please review to make sure this behavior aligns with your intent for the plot function. this somewhat reverts your January changes which excluded ROMS completely.

@sgaichas adding you as a second reviewer since this change was your request.