### PR TITLE
Feature(#402): plot ppr modifications

### DIFF
--- a/R/plot_ppr.R
+++ b/R/plot_ppr.R
@@ -1,6 +1,6 @@
 #' Plot ecosystem overfishing indices
 #'
-#' Plots ppr dataset. Primary production (PP), Fogarty and Ryther indices. Primary production required scaled by Primary production and mean trophic level index
+#' Plots ppr dataset. Primary production (PP), Fogarty and Ryther indices, primary production required (ppr) scaled by primary production, and mean trophic level (mtl) index
 #'
 #' @param shadedRegion Numeric vector. Years denoting the shaded region of the plot (most recent 10)
 #' @param report Character string. Which SOE report ("MidAtlantic", "NewEngland")

--- a/R/plot_ppr.R
+++ b/R/plot_ppr.R
@@ -1,10 +1,11 @@
-#' plot ecosystem overfishing indices
+#' Plot ecosystem overfishing indices
 #'
-#' plots ppr dataset. Primary production (PP), Fogarty, Ryther indices
+#' Plots ppr dataset. Primary production (PP), Fogarty and Ryther indices. Primary production required scaled by Primary production and mean trophic level index
 #'
 #' @param shadedRegion Numeric vector. Years denoting the shaded region of the plot (most recent 10)
 #' @param report Character string. Which SOE report ("MidAtlantic", "NewEngland")
-#' @param varName Character string. Variable to plot ("pp","fogarty","ryther")
+#' @param EPU Character string. Which EPU for New England report ("GB", "GOM") Mid will always be "MAB"
+#' @param varName Character string. Variable to plot ("pp","fogarty","ryther","ppr","mtl")
 #' @param threshold Character string. Select how thresholds are calculated ("global","regional")
 #'
 #' @return ggplot object
@@ -16,6 +17,7 @@
 plot_ppr <- function(
   shadedRegion = NULL,
   report = "MidAtlantic",
+  EPU = "MAB",
   varName = "ryther",
   threshold = "global"
 ) {
@@ -24,6 +26,7 @@ plot_ppr <- function(
 
   if (threshold == "regional") {
     # not yet available
+    message("Regional thresholds are not yet available")
     return(p = NULL)
   }
 
@@ -31,15 +34,24 @@ plot_ppr <- function(
   if (report == "MidAtlantic") {
     filterEPUs <- c("MAB")
   } else {
-    filterEPUs <- c("GB", "GOM")
+    if (!(EPU %in% c("GB", "GOM"))) {
+      stop("For NewEngland the epu must be either 'GB' or 'GOM'")
+    }
+    filterEPUs <- EPU
   }
 
-  if (varName == "pp") {
+  if (!(tolower(varName) %in% c("ryther", "fogarty", "pp", "ppr", "mtl"))) {
+    stop(
+      "Please use one following for varName.  `ryther`, `fogarty`, `pp`, `ppr`, `mtl`"
+    )
+  }
+
+  if (tolower(varName) == "pp") {
     varName <- "PP"
     scalar <- 1 / 1e6
     vtitle <- "PP Reconstructed"
     vylab <- expression("mtC region"^-1 * "year"^-1 * "(millions)")
-  } else if (varName == "fogarty") {
+  } else if (tolower(varName) == "fogarty") {
     varName <- "Fogarty"
     scalar <- 1000
     vtitle <- "Fogarty Index"
@@ -50,7 +62,7 @@ plot_ppr <- function(
       gr_lw = 0.22
       rd_lw = 1
     } else {}
-  } else if (varName == "ryther") {
+  } else if (tolower(varName) == "ryther") {
     varName <- "Ryther"
     scalar <- 1
     vtitle <- "Ryther Index"
@@ -61,8 +73,16 @@ plot_ppr <- function(
       gr_lw = 0.3
       rd_lw = 3
     } else {}
-  } else {
-    stop("Please use one following for varName.  `ryther`, `fogarty`, or `pp`")
+  } else if (tolower(varName) == "mtl") {
+    varName = "MTL"
+    scalar <- 1
+    vtitle <- "Mean trophic level of landings"
+    vylab <- "Trophic Level"
+  } else if (tolower(varName) == "ppr") {
+    varName = "PPR"
+    scalar <- 1
+    vtitle <- "Primary production required (scaled)"
+    vylab <- "Proportion"
   }
 
   # optional code to wrangle ecodata object prior to plotting
@@ -97,6 +117,8 @@ plot_ppr <- function(
         alpha = setup$hline.alpha,
         linetype = setup$hline.lty
       )
+  } else if (varName %in% c("PPR", "MTL")) {
+    p <- p
   } else {
     p <- p +
       ggplot2::geom_ribbon(
@@ -115,47 +137,27 @@ plot_ppr <- function(
     ggplot2::geom_point() +
     ggplot2::geom_line() +
 
-    ggplot2::ggtitle(vtitle) +
+    ggplot2::ggtitle(paste0(EPU, " ", vtitle)) +
     ggplot2::ylab(vylab) +
-    ggplot2::xlab(ggplot2::element_blank()) +
-    ggplot2::facet_wrap(. ~ EPU) +
+    ggplot2::xlab("") +
+    #ggplot2::facet_wrap(. ~ EPU) +
     ecodata::theme_ts() +
     ecodata::theme_facet() +
     ecodata::theme_title()
 
-  # optional code for New England specific (2 panel) formatting
-  if (report == "NewEngland") {
-    p <- p +
-      ggplot2::theme(
-        legend.position = "bottom",
-        legend.title = ggplot2::element_blank()
-      )
-  }
+  # # optional code for New England specific (2 panel) formatting
+  # if (report == "NewEngland") {
+  #   p <- p +
+  #     ggplot2::theme(
+  #       legend.position = "bottom",
+  #       legend.title = ggplot2::element_blank()
+  #     )
+  # }
 
   return(p)
 }
 
 attr(plot_ppr, "report") <- c("MidAtlantic", "NewEngland")
-attr(plot_ppr, "varName") <- c("pp", "fogarty", "ryther")
+attr(plot_ppr, "EPU") <- c("MAB", "GB", "GOM")
+attr(plot_ppr, "varName") <- c("pp", "fogarty", "ryther", "ppr", "mtl")
 attr(plot_ppr, "threshold") <- c("global")
-
-# Paste commented original plot code chunk for reference
-# ecodata::dataset |>
-#   dplyr::filter(Var %in% c("..."),
-#                 EPU == "...") |>
-#   ... more dataset wrangling as necessary |>
-#   ggplot2::ggplot(aes(x = Time, y = Mean, group = Season))+
-#   ggplot2::annotate("rect", fill = shade.fill, alpha = shade.alpha,
-#                     xmin = x.shade.min , xmax = x.shade.max,
-#                     ymin = -Inf, ymax = Inf) +
-#   ggplot2::geom_ribbon(aes(ymin = Lower, ymax = Upper, fill = Season), alpha = 0.5)+
-#   ggplot2::geom_point()+
-#   ggplot2::geom_line()+
-#   ggplot2::ggtitle("Title")+
-#   ggplot2::ylab(expression("Y label"))+
-#   ggplot2::xlab(element_blank())+
-#   ecodata::geom_gls()+
-#   ecodata::theme_ts()+
-#   ecodata::theme_title()
-#
-#

--- a/man/plot_ppr.Rd
+++ b/man/plot_ppr.Rd
@@ -2,11 +2,12 @@
 % Please edit documentation in R/plot_ppr.R
 \name{plot_ppr}
 \alias{plot_ppr}
-\title{plot ecosystem overfishing indices}
+\title{Plot ecosystem overfishing indices}
 \usage{
 plot_ppr(
   shadedRegion = NULL,
   report = "MidAtlantic",
+  EPU = "MAB",
   varName = "ryther",
   threshold = "global"
 )
@@ -16,7 +17,9 @@ plot_ppr(
 
 \item{report}{Character string. Which SOE report ("MidAtlantic", "NewEngland")}
 
-\item{varName}{Character string. Variable to plot ("pp","fogarty","ryther")}
+\item{EPU}{Character string. Which EPU for New England report ("GB", "GOM") Mid will always be "MAB"}
+
+\item{varName}{Character string. Variable to plot ("pp","fogarty","ryther","ppr","mtl")}
 
 \item{threshold}{Character string. Select how thresholds are calculated ("global","regional")}
 }
@@ -24,5 +27,5 @@ plot_ppr(
 ggplot object
 }
 \description{
-plots ppr dataset. Primary production (PP), Fogarty, Ryther indices
+Plots ppr dataset. Primary production (PP), Fogarty and Ryther indices. Primary production required scaled by Primary production and mean trophic level index
 }


### PR DESCRIPTION
### Justification

`ecodata::ppr` was updated to include variables, `ppr` (primary production required) and `mtl` (mean trophic level). The associated plot function needed an update to accommodate these variables. This is the purpose of this PR. 
Note: NewEngland EPUs are no longer facet wrapped. They are now their own entity. Attributes added also

Fixes #402 

### Types of changes

What types of changes does this pull request introduce? Put an `x` in the boxes that apply.
This will inform the new release number.

- [ ] Fix (non-breaking change which fixes a bug)
- [x] Feature (non-breaking change which adds or changes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other change (if none of the other choices apply)

### Reviewer instructions

build package from this branch and run `ecodata::create_all_plots("ppr", write_only = TRUE)` to see the list of plots and  `ecodata::create_all_plots("ppr", write_only = FALSE)`  to plot them all. You can compare the existing plots with catalog.

Please check attributes are correct and that this will not break catalog

### Formatting

This repo contains an `air.toml` file that automatically formats code to a set of standards.
It is preferred that contributors and reviewers install the [Air](https://posit-dev.github.io/air/) formatting tool.
Code submitted in this pull request will be automatically checked for correct formatting.
