### PR TITLE
Docs(#405): fixes pkgdown build by including missing entry

### DIFF
--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -34,6 +34,7 @@ reference:
     contents:
     - ecodata
     - coast
+    - create_all_plots
     - cold_pool_sf
     - ches_bay_sf
     - epu_sf


### PR DESCRIPTION
### Justification

missing `create_all_plots` entry in `pkgdown` yml is going to cause workflow to fail when pulling into `main` and the documentation of the package will not reflect the current state. This PR add it

Fixes #405 

### Types of changes

What types of changes does this pull request introduce? Put an `x` in the boxes that apply.
This will inform the new release number.

- [ ] Fix (non-breaking change which fixes a bug)
- [ ] Feature (non-breaking change which adds or changes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other change (if none of the other choices apply)

### Reviewer instructions

run `pkgdown::build_site()` to confirm the docs build and the reference page is visible. There are other accessibility issues with the build, which will be fixed later

### Formatting

This repo contains an `air.toml` file that automatically formats code to a set of standards.
It is preferred that contributors and reviewers install the [Air](https://posit-dev.github.io/air/) formatting tool.
Code submitted in this pull request will be automatically checked for correct formatting.
