### PR TITLE
Refactor!(#413): Change default branch from `master` to `main`

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -2,9 +2,9 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master, dev, andy_fixcmd]
+    branches: [main, dev, andy_fixcmd]
   pull_request:
-    branches: [main, master, dev]
+    branches: [main, dev]
 
 name: R-CMD-check.yaml
 

--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - master
 
 
 jobs:

--- a/.github/workflows/verify_pr.yml
+++ b/.github/workflows/verify_pr.yml
@@ -2,7 +2,7 @@ name: Run PR Checks
 on:
   pull_request:
     branches:
-    - master
+    - main
 
 jobs:
   check_description:


### PR DESCRIPTION
### Justification

In recent years, the industry standard default branch name has changed from `master` to `main`. Adopting this standard will align this repository with others in EDAB, allow for more seamless integration of external tools and clarify collaboration with external partners. We can make this switch with minimal disruption and, therefore, benefit from the standardization without any tradeoffs. Acceptance of these changes will resolve #413.

### Types of changes

What types of changes does this pull request introduce?

- [ ] Fix (non-breaking change which fixes a bug)
- [ ] Feature (non-breaking change which adds or changes functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other change (if none of the other choices apply)

### Further comments

Even though none of the changes in this PR are breaking, this should still be considered a breaking change because end users will need to update their local clones in response to renaming the default branch.

There may be other downstream consequences of making this switch but they will be minor and should be very easy to handle. Any changes required elsewhere should be noted in separate issues and resolved independently of this initial PR.

### Reviewer instructions

This is one of many upcoming changes that will be handled exclusively by repository maintainers. These changes only affect product/repository infrastructure and do not involve any changes to content which would require an additional reviewer. @andybeet you will be the only reviewer, and may bypass restrictions to approve and merge. Please briefly review the changes for proper syntax and spelling. No other testing is required.