### PR TITLE
Feature(#410): update plot_condition to show absolute (not rescaled) condition

### DIFF
--- a/R/plot_condition.R
+++ b/R/plot_condition.R
@@ -72,9 +72,11 @@ plot_condition <- function(
 
   sortNames <- fix |>
     # group the species that have a dip in the 2000s
-    dplyr::filter(Time <= 2014, Time >= 2000) |>
+    # dplyr::filter(Time <= 2014, Time >= 2000) |>
     dplyr::group_by(Var) |>
-    dplyr::summarize(total = sum(scaleCond, na.rm = TRUE)) |>
+    # dplyr::summarize(total = sum(scaleCond, na.rm = TRUE)) |>
+    # order by mean condition
+    dplyr::summarize(total = mean(scaleCond, na.rm = TRUE)) |>
     dplyr::arrange(total) |>
     dplyr::mutate(Species = factor(Var, levels = unique(Var))) |>
     dplyr::pull(Species)

--- a/R/plot_condition.R
+++ b/R/plot_condition.R
@@ -5,6 +5,7 @@
 #' @param shadedRegion Numeric vector. Years denoting the shaded region of the plot (most recent 10)
 #' @param report Character string. Which SOE report ("MidAtlantic", "NewEngland")
 #' @param EPU Character string. Which EPU in the report ("GB", "GOM", "MAB")
+#' @param plottype Character string. How categories should be assigned ("scaled" rescales and assigns by quantiles, while "raw" assigns based on relative condition)
 #'
 #' @return ggplot object
 #'
@@ -15,7 +16,8 @@
 plot_condition <- function(
   shadedRegion = NULL,
   report = "MidAtlantic",
-  EPU = "MAB"
+  EPU = "MAB",
+  plottype = "scaled"
 ) {
   # generate plot setup list (same for all plot functions)
   setup <- ecodata::plot_setup(shadedRegion = shadedRegion, report = report)
@@ -35,20 +37,35 @@ plot_condition <- function(
   # optional code to wrangle ecodata object prior to plotting
   # e.g., calculate mean, max or other needed values to join below
 
-  fix <- ecodata::condition |>
-    dplyr::filter(EPU == filterEPUs) |>
-    dplyr::group_by(Var) |>
-    dplyr::mutate(scaleCond = scale(Value, scale = T, center = T))
+  if (plottype == "scaled") {
+    fix <- ecodata::condition |>
+      dplyr::filter(EPU == filterEPUs) |>
+      dplyr::group_by(Var) |>
+      dplyr::mutate(scaleCond = scale(Value, scale = T, center = T))
+  } else if (plottype == "raw") {
+    fix <- ecodata::condition |>
+      dplyr::filter(EPU == filterEPUs) |>
+      dplyr::group_by(Var) |>
+      dplyr::mutate(scaleCond = Value)
+  } else {
+    stop("plottype must be either 'scaled' or 'raw'")
+  }
 
   # finds quantiles
   xs <- quantile(fix$scaleCond, seq(0, 1, length.out = 6), na.rm = TRUE)
-  # labels quantiles
+
   fix <- fix |>
     dplyr::mutate(
       category = cut(
         scaleCond,
         breaks = xs,
-        labels = c("Very Low", "Low", "Average", "High", "Very High"),
+        labels = c(
+          "Poor Condition",
+          "Below Average",
+          "Neutral",
+          "Above Average",
+          "Good Condition"
+        ),
         include.lowest = TRUE
       )
     )
@@ -61,7 +78,7 @@ plot_condition <- function(
     dplyr::mutate(Species = factor(Var, levels = unique(Var))) |>
     dplyr::pull(Species)
 
-  fix$Var <- factor(fix$Var, levels = sortNames)
+  # fix$Var <- factor(fix$Var, levels = sortNames)
 
   #See 5 scale colors for viridis:
   vir <- viridis::viridis_pal()(numberOfConditions)
@@ -72,18 +89,39 @@ plot_condition <- function(
   # xmin = setup$x.shade.min , xmax = setup$x.shade.max
   #
 
-  p <- fix |>
-    ggplot2::ggplot(ggplot2::aes(
-      x = Time,
-      y = forcats::fct_rev(Var),
-      fill = category
-    )) +
-    ggplot2::labs(fill = "Quantiles of Condition") +
+  if (plottype == "scaled") {
+    p <- fix |>
+      ggplot2::ggplot(ggplot2::aes(
+        x = Time,
+        y = forcats::fct_rev(Var),
+        fill = category
+      )) +
+      ggplot2::scale_fill_manual(values = vir)
+  } else if (plottype == "raw") {
+    p <- fix |>
+      ggplot2::ggplot(ggplot2::aes(
+        x = Time,
+        y = forcats::fct_rev(Var),
+        fill = scaleCond
+      )) +
+      # viridis::scale_fill_viridis(
+      #   discrete = FALSE #,
+      #   # option = "turbo",
+      #   # direction = -1
+      # )
+      ggplot2::scale_fill_gradientn(
+        colors = c(viridis::rocket(4)[2:4], viridis::mako(4)[4:2]),
+        # limits = c(min(fix$scaleCond), max(fix$scaleCond)),
+        values = scales::rescale(xs, from = c(min(xs), max(xs)), to = c(0, 1))
+      )
+  }
+
+  p <- p +
     ggplot2::geom_tile() +
     ggplot2::coord_equal() +
     ggplot2::theme_bw() +
-    ggplot2::scale_fill_manual(values = vir) +
-    ggplot2::guides(fill = ggplot2::guide_legend(reverse = TRUE)) +
+    # ggplot2::guides(fill = ggplot2::guide_legend(reverse = TRUE)) +
+
     ggplot2::scale_x_continuous(
       breaks = round(seq(min(fix$Time), max(fix$Time), by = numberOfConditions))
     ) +
@@ -107,9 +145,86 @@ plot_condition <- function(
     ecodata::theme_ts() +
     ecodata::theme_title()
 
+  if (plottype == "scaled") {
+    p <- p +
+      ggplot2::labs(fill = "Quantiles of Condition")
+  } else if (plottype == "raw") {
+    p <- p +
+      ggplot2::labs(fill = "Relative Condition")
+  }
+
   return(p)
 }
 
-
-attr(plot_condition, "EPU") <- c("MAB", "GB", "GOM")
-attr(plot_condition, "report") <- c("MidAtlantic", "NewEngland")
+# plot_condition(plottype = "raw")
+# plot_condition()
+#
+# dat <- ecodata::condition |>
+#   dplyr::group_by(Var, EPU) |>
+#   dplyr::filter(EPU != "SS") |>
+#   dplyr::mutate(
+#     scaleCond = scale(Value, scale = T, center = T)
+#   ) |>
+#   dplyr::ungroup() |>
+#   dplyr::mutate(
+#     cat = cut(
+#       scaleCond,
+#       breaks = quantile(
+#         dat$scaleCond,
+#         seq(0, 1, length.out = 6),
+#         na.rm = TRUE
+#       ),
+#       labels = c(
+#         "Poor Condition",
+#         "Below Average",
+#         "Neutral",
+#         "Above Average",
+#         "Good Condition"
+#       ),
+#       include.lowest = TRUE
+#     ),
+#     cat2 = cut(
+#       Value,
+#       breaks = quantile(
+#         dat$Value,
+#         seq(0, 1, length.out = 6),
+#         na.rm = TRUE
+#       ),
+#       labels = c(
+#         "Poor Condition",
+#         "Below Average",
+#         "Neutral",
+#         "Above Average",
+#         "Good Condition"
+#       ),
+#       include.lowest = TRUE
+#     )
+#   )
+#
+# dat |>
+#   dplyr::group_by(cat) |>
+#   dplyr::summarise(min = min(Value), max = max(Value))
+#
+# dat |>
+#   dplyr::group_by(cat2) |>
+#   dplyr::summarise(min = min(Value), max = max(Value))
+#
+# dat |>
+#   dplyr::group_by(Var) |>
+#   dplyr::summarise(delta = max(Value) - min(Value)) |>
+#   dplyr::arrange(delta)
+#
+# dat |>
+#   ggplot2::ggplot(ggplot2::aes(x = Value, y = scaleCond, color = Var)) +
+#   ggplot2::geom_point() +
+#   ggplot2::theme_bw() +
+#   ggplot2::facet_wrap(~EPU, ncol = 1) +
+#   ggplot2::geom_hline(
+#     yintercept = quantile(
+#       dat$scaleCond,
+#       seq(0, 1, length.out = 6),
+#       na.rm = TRUE
+#     ),
+#     lty = 2
+#   ) +
+#   ggplot2::theme(legend.position = "none")

--- a/R/plot_condition.R
+++ b/R/plot_condition.R
@@ -71,14 +71,15 @@ plot_condition <- function(
     )
 
   sortNames <- fix |>
-    dplyr::filter(Time <= 2014) |>
+    # group the species that have a dip in the 2000s
+    dplyr::filter(Time <= 2014, Time >= 2000) |>
     dplyr::group_by(Var) |>
-    dplyr::summarize(total = sum(scaleCond)) |>
+    dplyr::summarize(total = sum(scaleCond, na.rm = TRUE)) |>
     dplyr::arrange(total) |>
     dplyr::mutate(Species = factor(Var, levels = unique(Var))) |>
     dplyr::pull(Species)
 
-  # fix$Var <- factor(fix$Var, levels = sortNames)
+  fix$Var <- factor(fix$Var, levels = sortNames)
 
   #See 5 scale colors for viridis:
   vir <- viridis::viridis_pal()(numberOfConditions)
@@ -87,7 +88,6 @@ plot_condition <- function(
   # ensure that setup list objects are called as setup$...
   # e.g. fill = setup$shade.fill, alpha = setup$shade.alpha,
   # xmin = setup$x.shade.min , xmax = setup$x.shade.max
-  #
 
   if (plottype == "scaled") {
     p <- fix |>
@@ -104,14 +104,8 @@ plot_condition <- function(
         y = forcats::fct_rev(Var),
         fill = scaleCond
       )) +
-      # viridis::scale_fill_viridis(
-      #   discrete = FALSE #,
-      #   # option = "turbo",
-      #   # direction = -1
-      # )
       ggplot2::scale_fill_gradientn(
         colors = c(viridis::rocket(4)[2:4], viridis::mako(4)[4:2]),
-        # limits = c(min(fix$scaleCond), max(fix$scaleCond)),
         values = scales::rescale(xs, from = c(min(xs), max(xs)), to = c(0, 1))
       )
   }

--- a/R/plot_condition.R
+++ b/R/plot_condition.R
@@ -45,7 +45,6 @@ plot_condition <- function(
   } else if (plottype == "raw") {
     fix <- ecodata::condition |>
       dplyr::filter(EPU == filterEPUs) |>
-      dplyr::group_by(Var) |>
       dplyr::mutate(scaleCond = Value)
   } else {
     stop("plottype must be either 'scaled' or 'raw'")
@@ -71,10 +70,7 @@ plot_condition <- function(
     )
 
   sortNames <- fix |>
-    # group the species that have a dip in the 2000s
-    # dplyr::filter(Time <= 2014, Time >= 2000) |>
     dplyr::group_by(Var) |>
-    # dplyr::summarize(total = sum(scaleCond, na.rm = TRUE)) |>
     # order by mean condition
     dplyr::summarize(total = mean(scaleCond, na.rm = TRUE)) |>
     dplyr::arrange(total) |>
@@ -116,8 +112,6 @@ plot_condition <- function(
     ggplot2::geom_tile() +
     ggplot2::coord_equal() +
     ggplot2::theme_bw() +
-    # ggplot2::guides(fill = ggplot2::guide_legend(reverse = TRUE)) +
-
     ggplot2::scale_x_continuous(
       breaks = round(seq(min(fix$Time), max(fix$Time), by = numberOfConditions))
     ) +
@@ -154,73 +148,3 @@ plot_condition <- function(
 
 # plot_condition(plottype = "raw")
 # plot_condition()
-#
-# dat <- ecodata::condition |>
-#   dplyr::group_by(Var, EPU) |>
-#   dplyr::filter(EPU != "SS") |>
-#   dplyr::mutate(
-#     scaleCond = scale(Value, scale = T, center = T)
-#   ) |>
-#   dplyr::ungroup() |>
-#   dplyr::mutate(
-#     cat = cut(
-#       scaleCond,
-#       breaks = quantile(
-#         dat$scaleCond,
-#         seq(0, 1, length.out = 6),
-#         na.rm = TRUE
-#       ),
-#       labels = c(
-#         "Poor Condition",
-#         "Below Average",
-#         "Neutral",
-#         "Above Average",
-#         "Good Condition"
-#       ),
-#       include.lowest = TRUE
-#     ),
-#     cat2 = cut(
-#       Value,
-#       breaks = quantile(
-#         dat$Value,
-#         seq(0, 1, length.out = 6),
-#         na.rm = TRUE
-#       ),
-#       labels = c(
-#         "Poor Condition",
-#         "Below Average",
-#         "Neutral",
-#         "Above Average",
-#         "Good Condition"
-#       ),
-#       include.lowest = TRUE
-#     )
-#   )
-#
-# dat |>
-#   dplyr::group_by(cat) |>
-#   dplyr::summarise(min = min(Value), max = max(Value))
-#
-# dat |>
-#   dplyr::group_by(cat2) |>
-#   dplyr::summarise(min = min(Value), max = max(Value))
-#
-# dat |>
-#   dplyr::group_by(Var) |>
-#   dplyr::summarise(delta = max(Value) - min(Value)) |>
-#   dplyr::arrange(delta)
-#
-# dat |>
-#   ggplot2::ggplot(ggplot2::aes(x = Value, y = scaleCond, color = Var)) +
-#   ggplot2::geom_point() +
-#   ggplot2::theme_bw() +
-#   ggplot2::facet_wrap(~EPU, ncol = 1) +
-#   ggplot2::geom_hline(
-#     yintercept = quantile(
-#       dat$scaleCond,
-#       seq(0, 1, length.out = 6),
-#       na.rm = TRUE
-#     ),
-#     lty = 2
-#   ) +
-#   ggplot2::theme(legend.position = "none")


### PR DESCRIPTION
### Justification

Condition data is rescaled to mean = 0 and standard deviation = 1 for each species before plotting, which washes out the species-level variance (in other words, it obscures information about species that are "always fat" or "always skinny"). 

Fixes #410 

### Types of changes

What types of changes does this pull request introduce?

- [ ] Fix (non-breaking change which fixes a bug)
- [x] Feature (non-breaking change which adds or changes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other change (if none of the other choices apply)

### Further Comments

- Added `plottype` variable so the user can specify `plottype = "scaled"` (condition is colored by scaled value; same as in previous code) or `plottype = "raw"` (condition is colored by magnitude, not rescaled value)
- Created a new bicolor scale for `plottype = "raw"`

### Reviewer instructions

- Verify that setting `plottype = "scaled"` produces the same output as the current working version of `plot_condition`
- Compare a few years of `ecodata::condition` to the plot created with `plottype = "raw"` to ensure that the data matches the legend scale and magnitude