### PR TITLE
Feature(#431): Suppression argument for `create_all_plots` function

### DIFF
--- a/R/create_all_plots.R
+++ b/R/create_all_plots.R
@@ -6,13 +6,19 @@
 #'
 #' @param ecodata_name string. the data name of the target ecodata dataset or plot function (default = NULL)
 #' @param write_only boolean. should the function output the plotting code, as text, for all plot variations (default = FALSE)
+#' @param print boolean. should the function print output to the session window (default = TRUE)
 #' @param n numeric. number of data points for short term trend (default = 0)
 #'
 #' @return list containing plots when write_only = FALSE and text when write_only = TRUE. plots are also exported to the IDE plot pane.
 #'
 #' @export
 
-create_all_plots <- function(ecodata_name = NULL, write_only = FALSE, n = 0) {
+create_all_plots <- function(
+  ecodata_name = NULL,
+  write_only = FALSE,
+  print = TRUE,
+  n = 0
+) {
   # Define plot function syntax based on user input
   function_name <- paste0("ecodata::plot_", ecodata_name)
 
@@ -103,7 +109,9 @@ create_all_plots <- function(ecodata_name = NULL, write_only = FALSE, n = 0) {
       plotting_results[[i]] <- eval(parse(text = function_call))
     }
 
-    print(plotting_results[[i]])
+    if (print == TRUE) {
+      print(plotting_results[[i]])
+    }
   }
 
   # The function returns the 'plotting_results' list to the user

--- a/man/create_all_plots.Rd
+++ b/man/create_all_plots.Rd
@@ -4,12 +4,14 @@
 \alias{create_all_plots}
 \title{Create all variations of an ecodata plot function}
 \usage{
-create_all_plots(ecodata_name = NULL, write_only = FALSE, n = 0)
+create_all_plots(ecodata_name = NULL, write_only = FALSE, print = TRUE, n = 0)
 }
 \arguments{
 \item{ecodata_name}{string. the data name of the target ecodata dataset or plot function (default = NULL)}
 
 \item{write_only}{boolean. should the function output the plotting code, as text, for all plot variations (default = FALSE)}
+
+\item{print}{boolean. should the function print output to the session window (default = TRUE)}
 
 \item{n}{numeric. number of data points for short term trend (default = 0)}
 }


### PR DESCRIPTION
### Justification

To support unit testing, an argument has been added to `ecodata::create_all_plots` which suppresses the output of plots directly to the IDE session. This will reduce memory demand when running all unit tests, including when R-CMD and `devtools::check()` are used.
Fixes #431 

### Types of changes

- [ ] Fix (non-breaking change which fixes a bug)
- [x] Feature (non-breaking change which adds or changes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other change (if none of the other choices apply)

### Reviewer instructions

@andybeet since we've already discussed this, you will be the only reviewer. You may merge and delete the head branch after approval. Please load the package from the head branch and check revised function behavior (particularly when using the new `print` arg) and documentation. Thanks!
